### PR TITLE
FHIR-39272 - Add Composition profile example.

### DIFF
--- a/input/examples/composition-minimal.json
+++ b/input/examples/composition-minimal.json
@@ -1,0 +1,135 @@
+{
+  "resourceType": "Composition",
+  "id": "composition-minimal",
+  "status": "final",
+  "type": {
+    "coding": [
+      {
+        "code": "60591-5",
+        "system": "http://loinc.org",
+        "display": "Patient summary Document"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/patient-example-female"
+  },
+  "date": "2020-12-11T14:30:00+01:00",
+  "author": [
+    {
+      "reference": "Practitioner/eumfh-39-07"
+    }
+  ],
+  "title": "Patient Summary as of December 11, 2020 14:30",
+  "confidentiality": "N",
+  "attester": [
+    {
+      "mode": "legal",
+      "time": "2020-12-11T14:30:00+01:00",
+      "party": {
+        "reference": "Practitioner/eumfh-39-07"
+      }
+    },
+    {
+      "mode": "legal",
+      "time": "2020-12-11T14:30:00+01:00",
+      "party": {
+        "reference": "Organization/simple-org"
+      }
+    }
+  ],
+  "custodian": {
+    "reference": "Organization/simple-org"
+  },
+  "relatesTo": [
+    {
+      "code": "appends",
+      "targetIdentifier": {
+        "system": "urn:oid:2.16.724.4.8.10.200.10",
+        "value": "20e12ce3-857f-49c0-b888-cb670597f191"
+      }
+    }
+  ],
+  "event": [
+    {
+      "code": [
+        {
+          "coding": [
+            {
+              "code": "PCPR",
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActClass"
+            }
+          ]
+        }
+      ],
+      "period": {
+        "end": "2020-12-11T14:30:00+01:00"
+      }
+    }
+  ],
+  "section": [
+    {
+      "title": "Active Problems",
+      "code": {
+        "coding": [
+          {
+            "code": "11450-4",
+            "system": "http://loinc.org",
+            "display": "Problem list Reported"
+          }
+        ]
+      },
+      "text": {
+        "status": "generated",
+        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li><div><b>Condition Name</b>: Acute myocardial infarction of anterior wall</div><div><b>Code</b>: <span>54329005</span></div><div><b>Status</b>: <span>Active</span></div></li></ul></div>"
+      },
+      "entry": [
+        {
+          "reference": "Condition/eumfh-39-07-1"
+        }
+      ]
+    },
+    {
+      "title": "Medication",
+      "code": {
+        "coding": [
+          {
+            "code": "10160-0",
+            "system": "http://loinc.org",
+            "display": "History of Medication use Narrative"
+          }
+        ]
+      },
+      "text": {
+        "status": "generated",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li><div><b>Medication Name</b>: Simvastatin 40 MG Disintegrating Oral Tablet</div><div><b>Code</b>: <span>C10AA01</span></div><div><b>Status</b>: <span>Active, started 2014</span></div><div>Instructions: Take 40 mg/day</div></li></ul></div>"
+      },
+      "entry": [
+        {
+          "reference": "MedicationStatement/eumfh-39-07-1"
+        }
+      ]
+    },
+    {
+      "title": "Allergies and Intolerances",
+      "code": {
+        "coding": [
+          {
+            "code": "48765-2",
+            "system": "http://loinc.org",
+            "display": "Allergies and adverse reactions Document"
+          }
+        ]
+      },
+      "text": {
+        "status": "generated",
+        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li><div><b>Allergy Name</b>: No known allergies</div><div><b>Verification Status</b>: Confirmed</div><div><b>Reaction</b>: <span>no information</span></div></li></ul></div>"
+      },
+      "entry": [
+        {
+          "reference": "AllergyIntolerance/eumfh-39-07-1"
+        }
+      ]
+    }
+  ]
+}

--- a/input/ig-uv-ips.xml
+++ b/input/ig-uv-ips.xml
@@ -55,6 +55,14 @@
 			</reference>
 			<name value="IPS Bundle example - minimal"/>
 			<description value="IPS Bundle example - minimal"/>
+			<exampleCanonical value="http://hl7.org/fhir/uv/ips/StructureDefinition/Bundle-uv-ips"/>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="Composition/composition-minimal"/>
+			</reference>
+			<name value="IPS Composition example - minimal"/>
+			<description value="IPS Composition example - minimal"/>
 			<exampleCanonical value="http://hl7.org/fhir/uv/ips/StructureDefinition/Composition-uv-ips"/>
 		</resource>
 		<resource>

--- a/input/pagecontent/examples.md
+++ b/input/pagecontent/examples.md
@@ -7,6 +7,10 @@
 <ul>{% include list-simple-bundles.xhtml %}</ul>
 
 
+### Composition
+
+<ul>{% include list-simple-compositions.xhtml %}</ul>
+
 ### Condition
 
 <ul>{% include list-simple-conditions.xhtml %}</ul>


### PR DESCRIPTION
Add a Composition profile example with an 'exampleCanonical' reference to the IPS Composition profile.  Also change the 'exampleCanonical' reference for the "IPS Bundle example - minimal" example instance to refer to the IPS Bundle profile (instead of Composition).