### PR TITLE
Replace Observation Radiology component slices with a single ValueSet

### DIFF
--- a/input/fsh/profiles/ObservationResultsRadiologyUvIps.fsh
+++ b/input/fsh/profiles/ObservationResultsRadiologyUvIps.fsh
@@ -107,23 +107,4 @@ It allows also providing details about the related study using the partOf elemen
 * component ^extension[http://hl7.org/fhir/StructureDefinition/obligation][=].extension[actor].valueCanonical = "http://hl7.org/fhir/uv/ips/ActorDefinition/Consumer"
 * component ^extension[http://hl7.org/fhir/StructureDefinition/obligation][+].extension[code].valueCode = #SHOULD:display
 * component ^extension[http://hl7.org/fhir/StructureDefinition/obligation][=].extension[actor].valueCanonical = "http://hl7.org/fhir/uv/ips/ActorDefinition/Consumer"
-* component ^slicing.discriminator.type = #type
-* component ^slicing.discriminator.path = "value"
-* component ^slicing.description = "Slicing based on value[x] type."
-* component ^slicing.rules = #closed
-* component ^requirements = "Required if not(exists(Observation.valueString))"
-* component ^min = 0
-* component contains
-    observationCode 0..* and
-    observationTextOrMeasurement 0..*
-* component[observationCode] ^short = "Observation Code"
-* component[observationCode].code only CodeableConcept
-* component[observationCode].code from ResultsRadiologyObservationUvIps (preferred)
-* component[observationCode].value[x] 1..
-* component[observationCode].value[x] only CodeableConcept
-* component[observationTextOrMeasurement] ^short = "Observation Text or Measurement Values"
-* component[observationTextOrMeasurement].code only CodeableConcept
-* component[observationTextOrMeasurement].code from ResultsRadiologyMeasurementTextObservationUvIps (preferred)
-* component[observationTextOrMeasurement].code ^binding.extension.url = "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName"
-* component[observationTextOrMeasurement].code ^binding.extension.valueString = "ObservationCode"
-* component[observationTextOrMeasurement].value[x] 1..
+* component.code from ResultsRadiologyComponentUvIps (preferred)

--- a/input/fsh/valuesets/ResultsRadiologyComponentUvIps.fsh
+++ b/input/fsh/valuesets/ResultsRadiologyComponentUvIps.fsh
@@ -1,7 +1,7 @@
-ValueSet: ResultsRadiologyMeasurementTextObservationUvIps
-Id: results-radiology-numobs-uv-ips
-Title: "Results Radiology Measurement Observation - IPS"
-Description: "Extensible value set including SNOMED CT, LOINC and DICOM concepts for textual reports as well as linear, area and Volume Measurements"
+ValueSet: ResultsRadiologyComponentUvIps
+Id: results-radiology-component-uv-ips
+Title: "Results Radiology Component - IPS"
+Description: "Value set including SNOMED CT, LOINC and DICOM concepts for textual reports, measurements, and other radiology components"
 * ^meta.profile = "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
 * ^status = #active
 * ^experimental = false
@@ -10,7 +10,11 @@ Description: "Extensible value set including SNOMED CT, LOINC and DICOM concepts
 * ^contact.telecom.value = "http://www.hl7.org/Special/committees/patientcare"
 * ^jurisdiction = $m49.htm#001
 * ^immutable = false
-* ^copyright = "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement"
+* ^copyright = "\n- This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.\n- This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc"
+
+* include codes from valueset ResultsRadiologyObservationUvIps
+
+// textual reports
 * $DCM#121065 "Procedure Description"
 * $DCM#121069 "Previous Finding"
 * $DCM#121071 "Finding"
@@ -22,6 +26,8 @@ Description: "Extensible value set including SNOMED CT, LOINC and DICOM concepts
 * LOINC#11329-0 "History"
 * LOINC#55115-0 "Request"
 * SNOMED_CT#116224001 "Complication of Procedure"
+
+// measurements
 * $DCM#121207 "Height"
 * $DCM#121211 "Path length"
 * $DCM#121206 "Distance"


### PR DESCRIPTION
Currently, the [Observation Radiology](https://build.fhir.org/ig/HL7/fhir-ips/StructureDefinition-Observation-results-radiology-uv-ips.html) profile defines 2 slices on `component` (slicing based on the `value[x]` type), each with a different preferred binding:
1.  ResultsRadiologyObservationUvIps (all LOINC codes in the RAD class)
2.  ResultsRadiologyMeasurementTextObservationUvIps (specific DICOM, SNOMED, and LOINC codes for textual reports and measurements)

There's a few technical problems with the current approach. This PR is one option: combine the two ValueSets into one (ResultsRadiologyComponentUvIps), and add that as a general binding to `component.code`, with no slicing on `component`. However, other options are possible depending on the extent we want to profile out `component`.

---

Problems with the current approach:
1. The slice of RAD class LOINC codes only allows `CodeableConcept` as a `value[x]` type, but there's various LOINC codes that should use a different data type (like measurements of density)
2. Both slices allow `CodeableConcept` as a `value[x]` type, so the slice match is ambiguous when `component.valueCodeableConcept` exists
3. No slices allow for `component.dataAbsentReason`, and the slicing is closed