### PR TITLE
FHIR-51257 revert ConditionUvIps verificationStatus and PractitionerRoleUvIps code elements to type of CodeableConcept

### DIFF
--- a/input/fsh/profiles/ConditionUvIps.fsh
+++ b/input/fsh/profiles/ConditionUvIps.fsh
@@ -20,7 +20,7 @@ Description: "This profile represents the constraints applied to the Condition r
 * clinicalStatus ^extension[http://hl7.org/fhir/StructureDefinition/obligation][=].extension[actor].valueCanonical = "http://hl7.org/fhir/uv/ips/ActorDefinition/Consumer"
 * clinicalStatus ^extension[http://hl7.org/fhir/StructureDefinition/obligation][+].extension[code].valueCode = #SHOULD:display
 * clinicalStatus ^extension[http://hl7.org/fhir/StructureDefinition/obligation][=].extension[actor].valueCanonical = "http://hl7.org/fhir/uv/ips/ActorDefinition/Consumer"
-* verificationStatus only CodeableConceptIPS
+* verificationStatus only CodeableConcept
 * verificationStatus ^comment = "This element is labeled as a modifier because the status contains the code refuted and entered-in-error that mark the Condition as not currently valid."
 * category only CodeableConcept
 * category MS

--- a/input/fsh/profiles/PractitionerRoleUvIps.fsh
+++ b/input/fsh/profiles/PractitionerRoleUvIps.fsh
@@ -19,7 +19,7 @@ Description: "This profile constrains the PractitionerRole resource to represent
 * organization ^extension[http://hl7.org/fhir/StructureDefinition/obligation][=].extension[actor].valueCanonical = "http://hl7.org/fhir/uv/ips/ActorDefinition/Consumer"
 * organization ^extension[http://hl7.org/fhir/StructureDefinition/obligation][+].extension[code].valueCode = #SHOULD:display
 * organization ^extension[http://hl7.org/fhir/StructureDefinition/obligation][=].extension[actor].valueCanonical = "http://hl7.org/fhir/uv/ips/ActorDefinition/Consumer"
-* code only CodeableConceptIPS
+* code only CodeableConcept
 * code from HealthcareProfessionalRolesUvIps (preferred)
 * code ^definition = "Roles which this practitioner is authorized to perform for the organization."
 * code ^binding.extension.url = "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName"


### PR DESCRIPTION
FHIR-51257 listed ConditionUvIps verificationStatus to have element type reverted to CodeableConcept but this had not be updated.
PractitionerRoleUvIps code was not in the FHIR-51257 list of elements to be changed, but this was not flagged as MS so for consistency this element's type should also be reverted to CodeableConcept, 