### PR TITLE
Clarify IPS Server CapabilityStatement description

### DIFF
--- a/input/fsh/CapabilityStatement-uv-ips.fsh
+++ b/input/fsh/CapabilityStatement-uv-ips.fsh
@@ -1,7 +1,7 @@
 Instance: ips-server
 InstanceOf: CapabilityStatement
 Title: "IPS Server Capability Statement"
-Description: "This section describes the expected capabilities of the IPS Server actor which is responsible for providing responses to the queries submitted for IPS documents. The list of FHIR profiles and operations supported by IPS Servers are defined in this CapabilityStatement."
+Description: "This CapabilityStatement describes the expected capabilities of the IPS Server actor which is responsible for providing responses to the queries submitted for IPS documents. The list of FHIR profiles and operations supported by IPS Servers are defined in this CapabilityStatement."
 Usage: #definition
 * url = "http://hl7.org/fhir/uv/ips/CapabilityStatement/ips-server"
 * version = "1.1.0"

--- a/input/fsh/CapabilityStatement-uv-ips.fsh
+++ b/input/fsh/CapabilityStatement-uv-ips.fsh
@@ -1,7 +1,7 @@
 Instance: ips-server
 InstanceOf: CapabilityStatement
 Title: "IPS Server Capability Statement"
-Description: "This section describes the expected capabilities of the IPS Server actor which is responsible for providing responses to the queries submitted for IPS documents. The list of FHIR profiles and operations supported by IPS Servers are defined."
+Description: "This section describes the expected capabilities of the IPS Server actor which is responsible for providing responses to the queries submitted for IPS documents. The list of FHIR profiles and operations supported by IPS Servers are defined in this CapabilityStatement."
 Usage: #definition
 * url = "http://hl7.org/fhir/uv/ips/CapabilityStatement/ips-server"
 * version = "1.1.0"


### PR DESCRIPTION
This PR introduces non-normative changes to the IPS Server CapabilityStatement description to explicitly point to this CapabilityStatement. 

Changes 
- change 'section' to 'CapabilityStatement'
- change  “…The list of FHIR profiles and operations supported by IPS Servers are defined.” to “…The list of FHIR profiles and operations supported by IPS Servers are defined in this CapabilityStatement.”