### PR TITLE
Dependencies - add extensions pack canonical

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -24,7 +24,7 @@ jurisdiction: http://unstats.un.org/unsd/methods/m49/m49.htm#001 "World"
 dependencies:
   hl7.fhir.uv.extensions.r4:
     version: 5.3.0-ballot-tc1
-    uri: http://hl7.org/fhir/extensions
+    uri: http://hl7.org/fhir/extensions/ImplementationGuide/hl7.fhir.uv.extensions
 menu:
   Home: index.html
   Table of Contents: toc.html


### PR DESCRIPTION
Changes in this PR:
- add extensions pack canonical to dependsOn, to remove the QA error: "The URL should refer directly to the ImplementationGuide resource (e.g. include '/ImplementationGuide/')"