### PR TITLE
Update CapabilityStatement description

### DIFF
--- a/input/fsh/CapabilityStatement-uv-ips.fsh
+++ b/input/fsh/CapabilityStatement-uv-ips.fsh
@@ -13,7 +13,7 @@ Usage: #definition
 * publisher = "HL7 International / Patient Care"
 * contact.telecom.system = #url
 * contact.telecom.value = "http://www.hl7.org/Special/committees/patientcare"
-* description = "Capability Statement for IPS Server."
+* description = "This CapabilityStatement describes the expected capabilities of the [IPS Server actor](ActorDefinition-Server.html) which is responsible for providing responses to the queries submitted for IPS documents. The list of FHIR profiles and operations supported by IPS Servers are defined in this CapabilityStatement."
 * jurisdiction = $m49.htm#001
 * copyright = "Used by permission of HL7 International, all rights reserved Creative Commons License"
 * kind = #requirements

--- a/input/pagecontent/CapabilityStatement-ips-server-intro.md
+++ b/input/pagecontent/CapabilityStatement-ips-server-intro.md
@@ -1,3 +1,1 @@
 ### IPS Server Capability Statement
-
-This section describes the expected capabilities of the [IPS Server](./ActorDefinition-Server.html) actor which is responsible for providing responses to the queries submitted for IPS documents. The list of FHIR profiles and operations supported by IPS Servers are defined


### PR DESCRIPTION
@jddamore, please reject if you disagree with these changes:
1. Removed incomplete paragraph from CapabilityStatement-ips-server-intro.md - this was rendering at the top of the CapabilityStatement page.
2. Updated CapabilityStatement.description to match the metadata description we changed the other day, and link to IPS Server actor as well. This now renders as the first paragraph on the page.