### PR TITLE
Community review: align verificationStatus and MedicationStatement and MedicationRequest status codes with comment

### DIFF
--- a/input/fsh/profiles/AllergyIntoleranceUvIps.fsh
+++ b/input/fsh/profiles/AllergyIntoleranceUvIps.fsh
@@ -23,6 +23,7 @@ It documents the relevant allergies or intolerances for a patient, describing th
 * clinicalStatus ^extension[http://hl7.org/fhir/StructureDefinition/obligation][+].extension[code].valueCode = #SHOULD:display
 * clinicalStatus ^extension[http://hl7.org/fhir/StructureDefinition/obligation][=].extension[actor].valueCanonical = "http://hl7.org/fhir/uv/ips/ActorDefinition/Consumer"
 * verificationStatus only CodeableConcept
+* verificationStatus ^short = "unconfirmed | confirmed | refuted"
 * verificationStatus ^comment = "In the scope of the IPS the entered-in-error concept is not allowed."
 * type MS
 * type ^extension[http://hl7.org/fhir/StructureDefinition/obligation][+].extension[code].valueCode = #SHALL:populate-if-known

--- a/input/fsh/profiles/MedicationRequestIPS.fsh
+++ b/input/fsh/profiles/MedicationRequestIPS.fsh
@@ -13,6 +13,7 @@ Description: "This profile represents the constraints applied to the MedicationR
 * ^contact.telecom.value = "http://www.hl7.org/Special/committees/patientcare"
 * ^jurisdiction = $m49.htm#001
 * ^purpose = "This profile constrains the representation of a medication request related to the patient, in the context of the international patient summary as specified by the IPS project of HL7 International."
+* status ^short = "active | on-hold | cancelled | completed | stopped | draft | unknown"
 * status ^comment = "In the scope of the IPS the entered-in-error concept is not allowed."
 * doNotPerform 0..1
 * doNotPerform = false

--- a/input/fsh/profiles/MedicationStatementIPS.fsh
+++ b/input/fsh/profiles/MedicationStatementIPS.fsh
@@ -11,6 +11,7 @@ Description: "This profile represents the constraints applied to the MedicationS
 * ^contact.telecom.value = "http://www.hl7.org/Special/committees/patientcare"
 * ^jurisdiction = $m49.htm#001
 * ^purpose = "This profile constrains the representation of a medication statement related to the patient, in the context of the international patient summary as specified by the IPS project of HL7 International."
+* status ^short = "active | completed | intended | stopped | on-hold | unknown | not-taken"
 * status ^comment = "In the scope of the IPS the entered-in-error concept is not allowed."
 * medication[x] only CodeableConceptIPS or Reference(MedicationIPS)
 * medication[x] MS


### PR DESCRIPTION
Align AllergyIntoleranceUvIps.verificationStatus, MedicationRequestIPS.status and MedicationStatementIPS.status short with comment, which excludes entered-in-error