### PR TITLE
Community Review: ConditionUvIps.category and MedicationRequestIPS.medication as CodeableConceptIPS

### DIFF
--- a/input/fsh/profiles/ConditionUvIps.fsh
+++ b/input/fsh/profiles/ConditionUvIps.fsh
@@ -22,7 +22,7 @@ Description: "This profile represents the constraints applied to the Condition r
 * clinicalStatus ^extension[http://hl7.org/fhir/StructureDefinition/obligation][=].extension[actor].valueCanonical = "http://hl7.org/fhir/uv/ips/ActorDefinition/Consumer"
 * verificationStatus only CodeableConcept
 * verificationStatus ^comment = "This element is labeled as a modifier because the status contains the code refuted and entered-in-error that mark the Condition as not currently valid."
-* category only CodeableConcept
+* category only CodeableConceptIPS
 * category MS
 * category from ProblemTypeUvIps (extensible)
 * category ^extension[http://hl7.org/fhir/StructureDefinition/obligation][+].extension[code].valueCode = #SHALL:populate-if-known

--- a/input/fsh/profiles/MedicationRequestIPS.fsh
+++ b/input/fsh/profiles/MedicationRequestIPS.fsh
@@ -17,7 +17,7 @@ Description: "This profile represents the constraints applied to the MedicationR
 * doNotPerform 0..1
 * doNotPerform = false
 * doNotPerform ^comment = "In the scope of the IPS MedicationRequest, the doNotPerform concept is not allowed to be set to true. Other sections may be used to convey medications that a patient should or will not take."
-* medication[x] only CodeableConcept or Reference(MedicationIPS)
+* medication[x] only CodeableConceptIPS or Reference(MedicationIPS)
 * medication[x] MS
 * medication[x] ^extension[http://hl7.org/fhir/StructureDefinition/obligation][+].extension[code].valueCode = #SHALL:populate-if-known
 * medication[x] ^extension[http://hl7.org/fhir/StructureDefinition/obligation][=].extension[actor].valueCanonical = "http://hl7.org/fhir/uv/ips/ActorDefinition/Creator"


### PR DESCRIPTION
Update ConditionUvIps.category and MedicationRequestIPS.medication as only CodeableConceptIPS
- consistent with MedicationStatementIPS and ObservationResultsLaboratoryPathologyUvIps where elements are MS.